### PR TITLE
Fixed `get_address` implementation for `Manual{Manual{T}}`.

### DIFF
--- a/src/manuals.jl
+++ b/src/manuals.jl
@@ -77,7 +77,13 @@ macro v(expr)
 end
 
 function get_address(man::Manual{Manual{T}}, ::Type{Val{field}}) where {T, field}
-    get_address(Manual{T}(man.ptr), Val{field})
+    if field == :ptr
+        i = findfirst(fieldnames(Manual{T}), field)
+        @assert i != 0 "Manual{$T} has no field $field"
+        Manual{fieldtype(Manual{T}, i)}(man.ptr + fieldoffset(Manual{T}, i))
+    else
+        get_address(Manual{T}(man.ptr), Val{field})
+    end
 end
 
 @generated function get_address(man::Manual{T}, ::Type{Val{field}}) where {T, field}


### PR DESCRIPTION
Here is the example code provided by @tjgreen :

```julia
using ManualMemory

struct Foo
    x::ManualVector{Int}
    y::Float64
end

struct Bar
    a::Int
    b::Manual{Foo}
end


ManualMemory.alloc_size(::Type{Foo}, length) = ManualMemory.alloc_size(fieldtype(Foo, :x), length)

ManualMemory.alloc_size(::Type{Bar}, length) = ManualMemory.alloc_size(fieldtype(Bar, :b), length)

function ManualMemory.init(ptr::Ptr{Void}, foo::Manual{Foo}, length)
    ptr = ManualMemory.init(ptr, (@a foo.x), length)
    ptr
end

function ManualMemory.init(ptr::Ptr{Void}, bar::Manual{Bar}, length)
    ptr = ManualMemory.init(ptr, (@a bar.b), length)
    ptr
end

foo = ManualMemory.malloc(Foo, 8)

bar = ManualMemory.malloc(Bar, 8)
```

It was throwing the following error:

```
ERROR: LoadError: AssertionError: Foo has no field ptr
Stacktrace:
 [1] get_address(...) at /Users/dashti/.julia/v0.6/ManualMemory/src/manuals.jl:91
 [2] init(::Ptr{Void}, ::ManualMemory.Manual{ManualMemory.Manual{Foo}}, ::Int64) at /Users/dashti/.julia/v0.6/ManualMemory/src/manual_alloc.jl:36
 [3] init(::Ptr{Void}, ::ManualMemory.Manual{Bar}, ::Int64) at /Users/dashti/Desktop/testman.jl:24
 [4] malloc(::Type{Bar}, ::Int64, ::Vararg{Int64,N} where N) at /Users/dashti/.julia/v0.6/ManualMemory/src/manual_alloc.jl:83
 [5] include_from_node1(::String) at ./loading.jl:576
 [6] include(::String) at ./sysimg.jl:14
 [7] process_options(::Base.JLOptions) at ./client.jl:305
 [8] _start() at ./client.jl:371
while loading /Users/dashti/Desktop/testman.jl, in expression starting on line 34
```

This fix solves the issue, but it's dangerous if `T` also has a `ptr` field and user actually intends to get the address of that field. We can reduce the risk of this case by using a more obscure name rather than `ptr` or prevent users from having `T` with a field named `ptr`!